### PR TITLE
Add proxy support for DSS plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.dataiku.dss.intellij'
-version '1.0.3'
+version '1.1.0'
 
 sourceCompatibility = 1.8
 
@@ -23,6 +23,7 @@ intellij {
 }
 patchPluginXml {
     changeNotes """
+        1.1.0: Add support for HTTP proxy.<br>
         1.0.3: Add more logs to better diagnose issues.<br>
         1.0.2: Add more logs in case plugin cannot connect to DSS.<br>
         1.0.1: Various bug fixes<br>

--- a/src/main/java/com/dataiku/dss/intellij/actions/checkout/CheckoutStep1.java
+++ b/src/main/java/com/dataiku/dss/intellij/actions/checkout/CheckoutStep1.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.Nullable;
 import com.dataiku.dss.intellij.config.DssInstance;
 import com.dataiku.dss.intellij.config.DssSettings;
 import com.dataiku.dss.model.DSSClient;
+import com.dataiku.dss.model.dss.DssException;
 import com.intellij.ide.wizard.AbstractWizardStepEx;
 import com.intellij.ide.wizard.CommitStepException;
 import com.intellij.openapi.module.Module;
@@ -118,8 +119,10 @@ public class CheckoutStep1 extends AbstractWizardStepEx {
     }
 
     private DssInstance validateDssInstance(InstanceItem instanceItem) throws CommitStepException {
-        if (!instanceItem.client.canConnect()) {
-            throw new CommitStepException("Unable to connect to the selected DSS instance. Make sure it is running and reachable from your computer.");
+        try {
+            instanceItem.client.checkConnection();
+        } catch (DssException e) {
+            throw new CommitStepException("Unable to connect to the selected DSS instance. Make sure it is running and reachable from your computer.\n\n" + e.getMessage());
         }
         return instanceItem.instance;
     }

--- a/src/main/java/com/dataiku/dss/intellij/config/DssInstanceDialog.java
+++ b/src/main/java/com/dataiku/dss/intellij/config/DssInstanceDialog.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import com.dataiku.dss.Icons;
 import com.dataiku.dss.Logger;
 import com.dataiku.dss.model.DSSClient;
+import com.dataiku.dss.model.dss.DssException;
 import com.intellij.ide.wizard.CommitStepException;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.Messages;
@@ -193,17 +194,10 @@ public class DssInstanceDialog extends DialogWrapper {
         server.noCheckCertificate = disableSslCertificateCheckBox.isSelected();
 
         // Verify that we can connect to the server
-        if (!checkConnection()) {
-            throw new CommitStepException("Unable to connect to DSS using the provided URL and credentials.");
-        }
-    }
-
-    private boolean checkConnection() {
         try {
-            return server.createClient().canConnect();
-        } catch (RuntimeException e) {
-            log.info("Unable to connect to DSS", e);
-            return false;
+            server.createClient().checkConnection();
+        } catch (DssException e) {
+            throw new CommitStepException("Unable to connect to DSS using the provided URL and credentials.\n\n" + e.getMessage());
         }
     }
 

--- a/src/main/java/com/dataiku/dss/model/DSSClient.java
+++ b/src/main/java/com/dataiku/dss/model/DSSClient.java
@@ -6,42 +6,24 @@ import static java.util.Arrays.asList;
 import static org.apache.commons.codec.binary.Base64.encodeBase64;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javax.net.ssl.SSLContext;
 
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
-import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.ssl.SSLContextBuilder;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import com.dataiku.dss.Logger;
 import com.dataiku.dss.model.dss.DssException;
@@ -50,15 +32,14 @@ import com.dataiku.dss.model.dss.Plugin;
 import com.dataiku.dss.model.dss.Project;
 import com.dataiku.dss.model.dss.Recipe;
 import com.dataiku.dss.model.dss.RecipeAndPayload;
+import com.dataiku.dss.model.http.HttpClientWithContext;
+import com.dataiku.dss.model.http.HttpClientWithContextBuilder;
 import com.google.common.base.Joiner;
 import com.google.common.io.ByteStreams;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
-import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.VfsUtil;
-import com.intellij.util.net.HttpConfigurable;
 
 @SuppressWarnings("UnstableApiUsage")
 public class DSSClient {
@@ -90,17 +71,15 @@ public class DSSClient {
     }
 
     public String getDssVersion() {
-        try (CloseableHttpClient client = createHttpClient()) {
+        try (HttpClientWithContext client = createHttpClient()) {
             URI url = buildUrl(PROJECTS, "");
             HttpResponse response = executeRequest(new HttpGet(url), client);
             Header header = response.getFirstHeader("DSS-Version");
-            if (header != null) {
-                return header.getValue();
-            }
-        } catch (IOException | GeneralSecurityException e) {
+            return header != null ? header.getValue() : null;
+        } catch (IOException e) {
+            log.info("Unable to retrieve DSS version", e);
             return null;
         }
-        return null;
     }
 
     public List<Project> listProjects(String... tags) throws DssException {
@@ -170,13 +149,13 @@ public class DSSClient {
 
     public void uploadPluginFile(String pluginId, String path, byte[] content) throws DssException {
         URI url = buildUrl(PLUGINS, pluginId, CONTENTS, path);
-        try (CloseableHttpClient client = createHttpClient()) {
+        try (HttpClientWithContext client = createHttpClient()) {
             HttpPost request = new HttpPost(url);
             request.setEntity(new ByteArrayEntity(content));
             executeRequest(request, client);
         } catch (DssException e) {
             throw e;
-        } catch (IOException | GeneralSecurityException e) {
+        } catch (IOException e) {
             throw new DssException(e);
         }
     }
@@ -185,6 +164,10 @@ public class DSSClient {
         String dummyFilePath = path + "/dummy" + UUID.randomUUID();
         uploadPluginFile(pluginId, dummyFilePath, new byte[0]);
         deletePluginFile(pluginId, dummyFilePath);
+    }
+
+    private HttpClientWithContext createHttpClient() throws DssException {
+        return new HttpClientWithContextBuilder(baseUrl, noCheckCertificate).build();
     }
 
     @NotNull
@@ -196,14 +179,14 @@ public class DSSClient {
     private byte[] executePutAndReturnByteArray(URI url, String body) throws DssException {
         log.debug("Executing PUT request to " + url);
 
-        try (CloseableHttpClient client = createHttpClient()) {
+        try (HttpClientWithContext client = createHttpClient()) {
             HttpPut request = new HttpPut(url);
             request.setEntity(new StringEntity(body));
             HttpResponse response = executeRequest(request, client);
             return ByteStreams.toByteArray(response.getEntity().getContent());
         } catch (DssException e) {
             throw e;
-        } catch (IOException | GeneralSecurityException e) {
+        } catch (IOException e) {
             throw new DssException(e);
         }
     }
@@ -228,13 +211,13 @@ public class DSSClient {
     private byte[] executeGetAndReturnByteArray(URI url) throws DssException {
         log.debug("Executing GET request to " + url);
         try {
-            try (CloseableHttpClient client = createHttpClient()) {
+            try (HttpClientWithContext client = createHttpClient()) {
                 HttpResponse response = executeRequest(new HttpGet(url), client);
                 return ByteStreams.toByteArray(response.getEntity().getContent());
             }
         } catch (DssException e) {
             throw e;
-        } catch (IOException | GeneralSecurityException e) {
+        } catch (IOException e) {
             throw new DssException(e);
         }
     }
@@ -242,82 +225,29 @@ public class DSSClient {
     private void executeDelete(URI url) throws DssException {
         log.debug("Executing DELETE request to " + url);
         try {
-            try (CloseableHttpClient client = createHttpClient()) {
+            try (HttpClientWithContext client = createHttpClient()) {
                 executeRequest(new HttpDelete(url), client);
             }
         } catch (DssException e) {
             throw e;
-        } catch (IOException | GeneralSecurityException e) {
+        } catch (IOException e) {
             throw new DssException(e);
         }
     }
 
-    private CloseableHttpClient createHttpClient() throws GeneralSecurityException, DssException {
-        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-        if (noCheckCertificate) {
-            SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
-            sslContextBuilder.loadTrustMaterial(null, (TrustStrategy) (chain, authType) -> true);
-            SSLContext sslContext = sslContextBuilder.build();
-
-            httpClientBuilder.setSSLSocketFactory(new SSLConnectionSocketFactory(sslContext));
-            httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
-            configureProxy(httpClientBuilder);
-        }
-        return httpClientBuilder.build();
-    }
-
-    private void configureProxy(HttpClientBuilder httpClientBuilder) throws DssException {
-        HttpConfigurable httpConfigurable = HttpConfigurable.getInstance();
-        if (!isHttpProxyEnabledForUrl(httpConfigurable, baseUrl)) {
-            return;
-        }
-        if (httpConfigurable.PROXY_TYPE_IS_SOCKS) {
-            throw new DssException("Socks proxy is not supported by DSS plugin");
-        }
-
-        HttpHost httpHost = new HttpHost(httpConfigurable.PROXY_HOST, httpConfigurable.PROXY_PORT);
-        httpClientBuilder.setProxy(httpHost);
-
-        if (httpConfigurable.PROXY_AUTHENTICATION) {
-            // Different ways to fetch login based on runtime version (SLI-95)
-            try {
-                Object proxyLogin = getProxyLogin(httpConfigurable);
-                if (proxyLogin != null) {
-                    String proxyUsername = proxyLogin.toString();
-                    String proxyPassword = httpConfigurable.getPlainProxyPassword();
-
-                    CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-                    credentialsProvider.setCredentials(new AuthScope(httpConfigurable.PROXY_HOST, httpConfigurable.PROXY_PORT),
-                            new UsernamePasswordCredentials(proxyUsername, proxyPassword));
-                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-                }
-            } catch (Exception e) {
-                throw new DssException("Could not fetch value for proxy login", e);
-            }
-        }
-    }
-
-    private boolean isProxyEnabled() {
-        try {
-            return isHttpProxyEnabledForUrl(HttpConfigurable.getInstance(), baseUrl);
-        } catch (RuntimeException e) {
-            return false;
-        }
-    }
-
     @NotNull
-    private HttpResponse executeRequest(HttpRequestBase request, HttpClient client) throws DssException {
+    private HttpResponse executeRequest(HttpRequestBase request, HttpClientWithContext client) throws DssException {
         addJsonContentTypeHeader(request);
         addAuthorizationHeader(request);
         HttpResponse response;
         try {
-            response = client.execute(request);
+            response = client.client.execute(request, client.context);
         } catch (IOException e) {
             throw new DssException(e);
         }
         int statusCode = response.getStatusLine().getStatusCode();
         if (statusCode != 200) {
-            throw new DssException(statusCode, "DSS" + (isProxyEnabled() ? " or HTTP proxy" : "") + " returned error code " + statusCode + ".");
+            throw new DssException(statusCode, "DSS" + (client.useProxy ? " or HTTP proxy" : "") + " returned error code " + statusCode + ".");
         }
         return response;
     }
@@ -351,44 +281,5 @@ public class DSSClient {
             result += '/';
         }
         return result;
-    }
-
-    /**
-     * Copy of {@link HttpConfigurable#isHttpProxyEnabledForUrl(String)}, which doesn't exist in IDEA 14.
-     */
-    private static boolean isHttpProxyEnabledForUrl(HttpConfigurable httpConfigurable, @Nullable String url) {
-        if (!httpConfigurable.USE_HTTP_PROXY) {
-            return false;
-        }
-        URI uri = url != null ? VfsUtil.toUri(url) : null;
-        return uri == null || !isProxyException(httpConfigurable, uri.getHost());
-    }
-
-    private static boolean isProxyException(HttpConfigurable httpConfigurable, @Nullable String uriHost) {
-        if (StringUtil.isEmptyOrSpaces(uriHost) || StringUtil.isEmptyOrSpaces(httpConfigurable.PROXY_EXCEPTIONS)) {
-            return false;
-        }
-
-        List<String> hosts = StringUtil.split(httpConfigurable.PROXY_EXCEPTIONS, ",");
-        for (String hostPattern : hosts) {
-            String regexpPattern = StringUtil.escapeToRegexp(hostPattern.trim()).replace("\\*", ".*");
-            if (Pattern.compile(regexpPattern).matcher(uriHost).matches()) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    @SuppressWarnings("JavaReflectionMemberAccess")
-    private static Object getProxyLogin(HttpConfigurable httpConfigurable) throws Exception {
-        try {
-            Field proxyLoginField = HttpConfigurable.class.getField("PROXY_LOGIN");
-            return proxyLoginField.get(httpConfigurable);
-        } catch (NoSuchFieldException ex) {
-            // field doesn't exist -> we are in version >= 2016.2
-            Method proxyLoginMethod = HttpConfigurable.class.getMethod("getProxyLogin");
-            return proxyLoginMethod.invoke(httpConfigurable);
-        }
     }
 }

--- a/src/main/java/com/dataiku/dss/model/http/ConnectionSocketViaProxyFactory.java
+++ b/src/main/java/com/dataiku/dss/model/http/ConnectionSocketViaProxyFactory.java
@@ -1,0 +1,28 @@
+package com.dataiku.dss.model.http;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+
+import com.dataiku.dss.Logger;
+import com.dataiku.dss.model.DSSClient;
+
+public class ConnectionSocketViaProxyFactory extends PlainConnectionSocketFactory {
+
+    private static final Logger log = Logger.getInstance(ConnectionSocketViaProxyFactory.class);
+
+    public ConnectionSocketViaProxyFactory() {
+        super();
+    }
+
+    @Override
+    public Socket createSocket(HttpContext context) {
+        InetSocketAddress socketAddress = (InetSocketAddress) context.getAttribute("socks.address");
+        Proxy proxy = new Proxy(Proxy.Type.SOCKS, socketAddress);
+        log.info("Creating HTTP socket configured with proxy");
+        return new Socket(proxy);
+    }
+}

--- a/src/main/java/com/dataiku/dss/model/http/HttpClientWithContext.java
+++ b/src/main/java/com/dataiku/dss/model/http/HttpClientWithContext.java
@@ -1,0 +1,24 @@
+package com.dataiku.dss.model.http;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.HttpContext;
+
+public class HttpClientWithContext implements Closeable {
+    public final CloseableHttpClient client;
+    public final HttpContext context;
+    public final boolean useProxy;
+
+    public HttpClientWithContext(CloseableHttpClient client, HttpContext context, boolean useProxy) {
+        this.client = client;
+        this.context = context;
+        this.useProxy = useProxy;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.client.close();
+    }
+}

--- a/src/main/java/com/dataiku/dss/model/http/HttpClientWithContextBuilder.java
+++ b/src/main/java/com/dataiku/dss/model/http/HttpClientWithContextBuilder.java
@@ -1,0 +1,97 @@
+package com.dataiku.dss.model.http;
+
+import java.net.InetSocketAddress;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.ssl.SSLInitializationException;
+
+import com.dataiku.dss.model.dss.DssException;
+
+public class HttpClientWithContextBuilder {
+    private final String baseUrl;
+    private final boolean noCheckCertificate;
+
+    public HttpClientWithContextBuilder(String baseUrl, boolean noCheckCertificate) {
+        this.baseUrl = baseUrl;
+        this.noCheckCertificate = noCheckCertificate;
+    }
+
+    public HttpClientWithContext build() throws DssException {
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+        HttpClientContext context = null;
+
+        ProxyConfiguration proxyConfig = ProxyConfigurationFactory.getProxyConfiguration(baseUrl);
+        boolean useProxy = proxyConfig.isEnabled();
+        if (!useProxy) {
+            httpClientBuilder.setSSLSocketFactory(new SSLConnectionSocketFactory(buildSSLContext(), buildHostNameVerifier()));
+        } else {
+            if (proxyConfig.isSock()) {
+                if (proxyConfig.hasAuthentication()) {
+                    throw new DssException("Socks proxy with authentication is not supported by DSS plugin");
+                }
+                Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create()
+                        .register("http", new ConnectionSocketViaProxyFactory())
+                        .register("https", new SSLConnectionSocketViaProxyFactory(buildSSLContext(), buildHostNameVerifier()))
+                        .build();
+                PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+                httpClientBuilder.setConnectionManager(connectionManager);
+
+                context = HttpClientContext.create();
+                context.setAttribute("socks.address", new InetSocketAddress(proxyConfig.host, proxyConfig.port));
+            } else {
+                httpClientBuilder.setSSLSocketFactory(new SSLConnectionSocketFactory(buildSSLContext(), buildHostNameVerifier()));
+                httpClientBuilder.setProxy(new HttpHost(proxyConfig.host, proxyConfig.port));
+                httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider(proxyConfig));
+            }
+        }
+        return new HttpClientWithContext(httpClientBuilder.build(), context, useProxy);
+    }
+
+    private CredentialsProvider credentialsProvider(ProxyConfiguration proxyConfig) {
+        if (proxyConfig.username != null) {
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(new AuthScope(proxyConfig.host, proxyConfig.port), new UsernamePasswordCredentials(proxyConfig.username, proxyConfig.password));
+            return credentialsProvider;
+        } else {
+            return null;
+        }
+    }
+
+    private HostnameVerifier buildHostNameVerifier() {
+        return noCheckCertificate ? NoopHostnameVerifier.INSTANCE : null;
+    }
+
+    private SSLContext buildSSLContext() {
+        if (noCheckCertificate) {
+            try {
+                SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
+                sslContextBuilder.loadTrustMaterial(null, (TrustStrategy) (chain, authType) -> true);
+                return sslContextBuilder.build();
+            } catch (KeyStoreException | NoSuchAlgorithmException | KeyManagementException e) {
+                throw new SSLInitializationException(e.getMessage(), e);
+            }
+        } else {
+            return SSLContexts.createSystemDefault();
+        }
+    }
+}

--- a/src/main/java/com/dataiku/dss/model/http/ProxyConfiguration.java
+++ b/src/main/java/com/dataiku/dss/model/http/ProxyConfiguration.java
@@ -1,0 +1,38 @@
+package com.dataiku.dss.model.http;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.jetbrains.annotations.Nullable;
+
+public class ProxyConfiguration {
+    public static final ProxyConfiguration NO_PROXY = new ProxyConfiguration(null, 0, false, null, null);
+
+    public final String host;
+    public final int port;
+    public final boolean sockProxy;
+    public final String username;
+    public final String password;
+
+    public ProxyConfiguration(String host, int port, boolean sockProxy, @Nullable String username, @Nullable String password) {
+        this.host = host;
+        this.port = port;
+        this.sockProxy = sockProxy;
+        this.username = username;
+        this.password = password;
+    }
+
+    public boolean isEnabled() {
+        return host != null && port != 0;
+    }
+
+    public boolean hasAuthentication() {
+        return username != null;
+    }
+
+    public boolean isSock() {
+        return sockProxy;
+    }
+
+}

--- a/src/main/java/com/dataiku/dss/model/http/ProxyConfigurationFactory.java
+++ b/src/main/java/com/dataiku/dss/model/http/ProxyConfigurationFactory.java
@@ -1,0 +1,83 @@
+package com.dataiku.dss.model.http;
+
+import static com.dataiku.dss.model.http.ProxyConfiguration.NO_PROXY;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.dataiku.dss.model.dss.DssException;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.util.net.HttpConfigurable;
+
+public class ProxyConfigurationFactory {
+
+    public static ProxyConfiguration getProxyConfiguration(String baseUrl) throws DssException {
+        HttpConfigurable httpConfig = HttpConfigurable.getInstance();
+        if (!isHttpProxyEnabledForUrl(httpConfig, baseUrl)) {
+            return NO_PROXY;
+        }
+
+        boolean sockProxy = httpConfig.PROXY_TYPE_IS_SOCKS;
+        String proxyHost = httpConfig.PROXY_HOST;
+        int proxyPort = httpConfig.PROXY_PORT;
+        String proxyUsername = null;
+        String proxyPassword = null;
+        if (httpConfig.PROXY_AUTHENTICATION) {
+            try {
+                Object proxyLogin = getProxyLogin(httpConfig);
+                if (proxyLogin != null) {
+                    proxyUsername = proxyLogin.toString();
+                    proxyPassword = httpConfig.getPlainProxyPassword();
+                }
+            } catch (Exception e) {
+                throw new DssException("Could not fetch value for proxy login", e);
+            }
+        }
+        return new ProxyConfiguration(proxyHost, proxyPort, sockProxy, proxyUsername, proxyPassword);
+    }
+
+    /**
+     * Copy of {@link HttpConfigurable#isHttpProxyEnabledForUrl(String)}, which doesn't exist in IDEA 14.
+     */
+    private static boolean isHttpProxyEnabledForUrl(HttpConfigurable httpConfigurable, @Nullable String url) {
+        if (!httpConfigurable.USE_HTTP_PROXY) {
+            return false;
+        }
+        URI uri = url != null ? VfsUtil.toUri(url) : null;
+        return uri == null || !isProxyException(httpConfigurable, uri.getHost());
+    }
+
+    private static boolean isProxyException(HttpConfigurable httpConfigurable, @Nullable String uriHost) {
+        if (StringUtil.isEmptyOrSpaces(uriHost) || StringUtil.isEmptyOrSpaces(httpConfigurable.PROXY_EXCEPTIONS)) {
+            return false;
+        }
+
+        List<String> hosts = StringUtil.split(httpConfigurable.PROXY_EXCEPTIONS, ",");
+        for (String hostPattern : hosts) {
+            String regexpPattern = StringUtil.escapeToRegexp(hostPattern.trim()).replace("\\*", ".*");
+            if (Pattern.compile(regexpPattern).matcher(uriHost).matches()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @SuppressWarnings("JavaReflectionMemberAccess")
+    private static Object getProxyLogin(HttpConfigurable httpConfigurable) throws Exception {
+        try {
+            Field proxyLoginField = HttpConfigurable.class.getField("PROXY_LOGIN");
+            return proxyLoginField.get(httpConfigurable);
+        } catch (NoSuchFieldException ex) {
+            // field doesn't exist -> we are in version >= 2016.2
+            Method proxyLoginMethod = HttpConfigurable.class.getMethod("getProxyLogin");
+            return proxyLoginMethod.invoke(httpConfigurable);
+        }
+    }
+}

--- a/src/main/java/com/dataiku/dss/model/http/SSLConnectionSocketViaProxyFactory.java
+++ b/src/main/java/com/dataiku/dss/model/http/SSLConnectionSocketViaProxyFactory.java
@@ -1,0 +1,32 @@
+package com.dataiku.dss.model.http;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+import org.jetbrains.annotations.Nullable;
+
+import com.dataiku.dss.Logger;
+
+public class SSLConnectionSocketViaProxyFactory extends SSLConnectionSocketFactory {
+
+    private static final Logger log = Logger.getInstance(SSLConnectionSocketViaProxyFactory.class);
+
+    public SSLConnectionSocketViaProxyFactory(SSLContext sslContext, @Nullable HostnameVerifier hostnameVerifier) {
+        super(checkNotNull(sslContext, "sslContext"), hostnameVerifier);
+    }
+
+    @Override
+    public Socket createSocket(HttpContext context) {
+        InetSocketAddress socketAddress = (InetSocketAddress) context.getAttribute("socks.address");
+        Proxy proxy = new Proxy(Proxy.Type.SOCKS, socketAddress);
+        log.info("Creating HTTPS socket configured with proxy");
+        return new Socket(proxy);
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.dataiku.dss.intellij</id>
     <name>Dataiku DSS</name>
-    <version>1.0.3</version>
+    <version>1.1.0</version>
     <vendor email="support@dataiku.com" url="http://www.dataiku.com">Dataiku</vendor>
 
     <description><![CDATA[
@@ -9,6 +9,7 @@
     ]]></description>
 
     <change-notes><![CDATA[
+        1.1.0: Add support for HTTP proxy.<br>
         1.0.3: Add more logs to better diagnose issues.<br>
         1.0.2: Add more logs in case plugin cannot connect to DSS.<br>
         1.0.1: Various bug fixes<br>


### PR DESCRIPTION
Allow DSS PyCharm plugin to connect to DSS when an HTTP proxy has been configured in PyCharm (Settings > HTTP Proxy)